### PR TITLE
ROCANA-7883: Fork metrics-jvm-nonaccumulating

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.apache.commons:commons-lang3:3.3.2'
+    compile 'org.apache.commons:commons-lang3:3.0'
     compile 'io.dropwizard.metrics:metrics-core:3.1.0'
     compile 'io.dropwizard.metrics:metrics-jvm:3.1.0'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.heapwhisperer.metrics.jvm
-version=1.0.2
+version=1.0.2-rocana2.0.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 20 20:53:51 CDT 2015
+#Tue Oct 25 16:45:35 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip


### PR DESCRIPTION
- Set the version of commons-lang3 to 3.0
- Set the version of metrics-jvm-nonaccumulating to
  1.0.2-rocana2.0.0-SNAPSHOT
- Update the gradle wrapper to use the version that supports better ide
  debugging.
