### PR TITLE
ROCANA-7885: Create a release job for the metrics-jvm-nonaccumulating project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id "com.jfrog.bintray" version "1.1"
+    id 'net.researchgate.release' version '2.4.0'
 }
 
 repositories {
@@ -44,6 +45,10 @@ task wrapper(type: Wrapper) {
     gradleVersion = '2.4'
 }
 
+release {
+    tagTemplate = 'metrics-jvm-nonaccumulating-${version}'
+}
+
 uploadArchives {
     repositories {
         mavenDeployer {
@@ -59,3 +64,5 @@ uploadArchives {
         }
     }
 }
+
+afterReleaseBuild.dependsOn uploadArchives


### PR DESCRIPTION
Tested this locally:
```
ip-192-168-1-14:metrics-jvm-nonaccumulating joey$ gradle release
:release
:metrics-jvm-nonaccumulating:createScmAdapter
:metrics-jvm-nonaccumulating:initScmAdapter
:metrics-jvm-nonaccumulating:checkCommitNeeded
:metrics-jvm-nonaccumulating:checkUpdateNeeded
:metrics-jvm-nonaccumulating:unSnapshotVersion
> Building 0% > :release > :metrics-jvm-nonaccumulating:confirmReleaseVersion
??> This release version: [1.0.2-rocana2.0.0] 1.0.2-rocana2.0.0-rc1
:metrics-jvm-nonaccumulating:confirmReleaseVersion
:metrics-jvm-nonaccumulating:checkSnapshotDependencies
:metrics-jvm-nonaccumulating:runBuildTasks
:metrics-jvm-nonaccumulating:beforeReleaseBuild UP-TO-DATE
:metrics-jvm-nonaccumulating:compileJava UP-TO-DATE
:metrics-jvm-nonaccumulating:processResources UP-TO-DATE
:metrics-jvm-nonaccumulating:classes UP-TO-DATE
:metrics-jvm-nonaccumulating:jar
:metrics-jvm-nonaccumulating:javadoc
:metrics-jvm-nonaccumulating:javadocJar
:metrics-jvm-nonaccumulating:sourcesJar
:metrics-jvm-nonaccumulating:assemble
:metrics-jvm-nonaccumulating:compileTestJava
:metrics-jvm-nonaccumulating:processTestResources UP-TO-DATE
:metrics-jvm-nonaccumulating:testClasses
:metrics-jvm-nonaccumulating:test
:metrics-jvm-nonaccumulating:check
:metrics-jvm-nonaccumulating:build
:metrics-jvm-nonaccumulating:uploadArchives
Could not find metadata com.heapwhisperer.metrics.jvm:metrics-jvm-nonaccumulating/maven-metadata.xml in remote (http://repository.rocana.com/content/repositories/com.scalingdata.releases)
:metrics-jvm-nonaccumulating:afterReleaseBuild
:metrics-jvm-nonaccumulating:preTagCommit
:metrics-jvm-nonaccumulating:createReleaseTag
> Building 0% > :release > :metrics-jvm-nonaccumulating:updateVersion
??> Enter the next version (current one released as [1.0.2-rocana2.0.0-rc1]): [1.0.2-rocana2.0.0-rc2-SNAPSHOT] 1.0.2-rocana2.0.0-SNAPSHOT
:metrics-jvm-nonaccumulating:updateVersion
:metrics-jvm-nonaccumulating:commitNewVersion

BUILD SUCCESSFUL

Total time: 1 mins 1.158 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.12/userguide/gradle_daemon.html
```

which created an rc1 release: http://repository.rocana.com/content/repositories/com.scalingdata.releases/com/heapwhisperer/metrics/jvm/metrics-jvm-nonaccumulating/1.0.2-rocana2.0.0-rc1/